### PR TITLE
Materialize semantic Capture reconciliation

### DIFF
--- a/cfg/home/agents/skills/capture/HTML-DRAFT.md
+++ b/cfg/home/agents/skills/capture/HTML-DRAFT.md
@@ -437,11 +437,15 @@ post-approval state.
 
 ### Revision Evidence
 
-For every mutation, show the source, actor, `captured_at`, affected owner, prior
-revision identity, proposed or expected revision identity, and exact diff. Include
+For every mutation, show the source, actor, the exact provider field or deterministic
+operation that will assign `captured_at` when the accepted mutation is applied,
+the affected owner, prior revision identity, proposed or expected revision
+identity, and exact diff. Include
 `observed_at` for every changed State and any `event_at`, `valid_from`, or
 `valid_until` that changes interpretation. Name each `supersedes`, `revises`, or
 `invalidates` relation and the provider location that will retain the evidence.
+Do not fabricate a pre-approval `captured_at` value or reuse the draft timestamp.
+Read-back must report and verify the resulting value assigned at apply time.
 
 The temporary HTML file is not durable provenance by itself. If the provider has
 no verified way to retain and link the required Revision Evidence after approval,
@@ -471,8 +475,11 @@ Each row must include:
 - blocking: yes or no, with reason.
 
 A bare status is invalid. Approval is not evidence. Unresolved Ownership,
-contradiction, material omission, unsupported assertion, or unsafe deletion must
-be blocking whether its status is `Flag` or `Not checked`.
+contradiction, material omission, an unsupported assertion retained or introduced
+in the proposed after-state, or unsafe deletion must be blocking whether its status
+is `Flag` or `Not checked`. An unsupported candidate that is explicitly rejected or
+omitted may pass Coverage and Faithfulness when the ledger proves it cannot enter
+the approved result.
 
 ### Blockers
 

--- a/cfg/home/agents/skills/capture/HTML-DRAFT.md
+++ b/cfg/home/agents/skills/capture/HTML-DRAFT.md
@@ -1,6 +1,10 @@
 # HTML Approval Draft
 
-The approval draft is a single HTML file in the OS temp directory that mimics the KB provider's own page view. It is an approval artifact, not a repo artifact. The shipped styling is a dark, Notion-style palette; apply the `draft-style` binding instead when it is set.
+The approval draft is a single HTML file in the OS temp directory that mimics the
+bound KB provider's own page view. It is an approval artifact, not a repo artifact.
+The shipped styling is a dark, Notion-style palette; apply the `draft-style`
+binding instead when it is set. Styling never changes the provider-agnostic
+semantic or approval contract.
 
 Resolve the temp directory from `$TMPDIR`, falling back to `/tmp` on Unix or `%TEMP%` on Windows. Write to:
 
@@ -12,13 +16,18 @@ Open the file for the user and report the absolute path in chat.
 
 ## Design Goal
 
-Make the draft feel like a deep preview of the final result inside the KB provider, not a generic report.
+Make the draft feel like a deep preview of the final result inside the bound KB
+provider, not a generic report. Exact before and after content, semantic decisions,
+deletions, Revision Evidence, and quality-gate evidence are part of the approval
+surface rather than hidden implementation detail.
 
 - Use a Notion-dark palette, Notion-like spacing, page typography, property rows, toggles, callouts, and database/table previews.
-- Render each proposed write as a Notion page preview.
+- Render each proposed write as a provider-like KB page preview.
 - For new pages, show a "New page preview" that resembles the page that would exist after approval.
-- For page updates, show an "Updated page preview" in the same Notion page shell, with inline block diffs and property diffs.
-- Keep evidence and skipped writes available, but visually secondary to the proposed final pages.
+- For page updates, show complete exact before and after views plus an inline diff
+  in the same KB page shell.
+- Put proposed results first. Keep source mapping and workspace-read evidence
+  available but visually secondary. Keep blockers and deletion risk prominent.
 
 ## Scaffold
 
@@ -30,7 +39,7 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Notion knowledge draft - {{topic}}</title>
+    <title>Knowledge Bank approval draft - {{topic}}</title>
     <style>
       :root {
         color-scheme: dark;
@@ -153,7 +162,9 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
       .pill.create { background: var(--blue-bg); color: #9cc2ff; }
       .pill.update { background: var(--yellow-bg); color: #f2c96d; }
       .pill.ok { background: var(--green-bg); color: #93d5a6; }
-      .notion-page {
+      .pill.blocked { background: var(--red-bg); color: #ffb2ac; }
+      .pill.flag { background: var(--yellow-bg); color: #f2c96d; }
+      .kb-page {
         background: var(--page-bg);
         border: 1px solid var(--line);
         border-radius: 8px;
@@ -258,11 +269,15 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
         padding: 16px;
         margin-top: 28px;
       }
+      .blocked-question {
+        border-color: var(--red);
+        background: var(--red-bg);
+      }
       @media (max-width: 820px) {
         .app { display: block; }
         .sidebar { display: none; }
         main { padding: 30px 22px 56px; }
-        .notion-page { padding: 26px 22px 32px; }
+        .kb-page { padding: 26px 22px 32px; }
         h1 { font-size: 32px; }
         .property-row { grid-template-columns: 1fr; gap: 2px; }
       }
@@ -280,12 +295,20 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
         <div class="page-icon">N</div>
         <h1>{{topic}}</h1>
         <div class="property-table">
-          <div class="property-row"><strong>Status</strong><span><span class="pill update">Not written to Notion</span></span></div>
+          <div class="property-row"><strong>Status</strong><span><span class="pill {{status_class}}">{{approval_status}}</span></span></div>
           <div class="property-row"><strong>Drafted</strong><span>{{date}}</span></div>
+          <div class="property-row"><strong>Draft identity</strong><span>{{draft_id}}</span></div>
+          <div class="property-row"><strong>Contract</strong><span>{{contract_version}}</span></div>
           <div class="property-row"><strong>Requires</strong><span>Fresh explicit approval</span></div>
         </div>
 
         <section id="proposed-results">...</section>
+        <section id="semantic-decisions">...</section>
+        <section id="revision-evidence">...</section>
+        <details id="source-assertions"><summary>Source assertion coverage</summary>...</details>
+        <details id="quality-gate" open><summary>Semantic Quality Gate</summary>...</details>
+        <section id="blockers">...</section>
+        <details id="read-back-plan"><summary>Read-back verification plan</summary>...</details>
         <details id="workspace-read"><summary>Workspace read</summary>...</details>
         <details id="skipped"><summary>Skipped or deferred writes</summary>...</details>
         <section id="questions" class="approval-question">...</section>
@@ -295,50 +318,81 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
 </html>
 ```
 
+Set `approval_status` to `Ready for approval - not written to KB` only when the
+quality gate has no blocking result. Otherwise use `Blocked - not approvable` and
+the `blocked` pill class. Use `draft_id` to make later approval refer to this exact
+artifact; do not reuse it after any content or gate result changes.
+
 ## Required Sections
 
 ### Proposed Results
 
-Put proposed results first. Use one Notion page preview per write.
+Put proposed results first in exact application order. Use one provider-like KB page
+preview per mutation. The sequence and preview together define what approval
+authorizes.
 
 Each preview must include:
 
-- target: database/page name and ID or URL
-- action: create, update, append, relate, move, rename, archive, or no-op
-- parent/placement: where the page or block will live
-- properties: exact property/value mapping from the live schema
-- relations: parent, linked projects, tasks, repo pages, or related owners
-- final page body or final block body
+- target database or page name plus stable ID or URL;
+- action: create, update, append, relate, move, rename, archive, or delete;
+- parent and exact block or section placement;
+- exact current and proposed property values from the live schema;
+- exact current and proposed relations, including canonical-owner links;
+- full final page or block body, without placeholders or ellipses;
+- each deleted property, relation, block, section, or page;
+- expected resulting revision identity when the provider can predict it; otherwise
+  the exact revision field that read-back must discover and verify.
 
-Do not use generic cards as the main preview. Cards can be used only inside the Notion-like page shell when a database/table preview is the natural final shape.
+No-op candidates belong under Skipped, not in the mutation sequence. Do not use
+generic cards as the main preview. Cards are acceptable only inside the page shell
+when a database or table is the provider's natural final representation.
 
 ### New Page Preview
 
 For creates, render a "New page preview" as the page that will exist after approval.
+State `Exact before: target absent`, with the search scope and evidence that the
+stable target does not already exist.
 
 Use this shape:
 
 ```html
-<article class="notion-page new-page">
+<article class="kb-page new-page">
   <div class="preview-label"><span class="pill create">Create</span> New page preview</div>
   <div class="breadcrumb">{{parent_path}}</div>
   <div class="page-icon">{{icon_or_initial}}</div>
   <h1>{{new_page_title}}</h1>
   <div class="property-table">...</div>
-  <div class="block">{{exact final Notion body}}</div>
+  <div class="block">{{exact final KB body}}</div>
 </article>
 ```
 
-The body must be source-free and should resemble the final Notion page: headings, short paragraphs, bullet blocks, callouts, tables, and child-page/database mentions where relevant.
+The body should resemble the final provider page: headings, short paragraphs,
+lists, callouts, tables, and child-page or database mentions where relevant. Keep
+approval provenance out of the final prose unless it changes interpretation, but
+still show it in the draft's Revision Evidence.
+
+### Deleted Page Or Block Preview
+
+For a deletion, show the complete exact page, section, block, property, or relation
+before deletion and its exact after-state: absent, invalidated, or replaced at the
+approved location. Include migrated unique content, rewritten inbound links, the
+recoverable revision identity, and the deletion-safety result. Do not use
+`archive`, `delete`, and `invalidate` interchangeably; show the actual provider
+operation and visible result.
+
+For relation-only, property-only, move, or rename operations, use the same exact
+before/after structure even when the body is unchanged.
 
 ### Updated Page Preview
 
-For updates, render an "Updated page preview" as the current page with the proposed changes inside it.
+For updates, render an "Updated page preview" with complete exact before and after
+content. Add an inline diff for review, but never make the reviewer reconstruct an
+after-state by applying the diff mentally.
 
 Use this shape:
 
 ```html
-<article class="notion-page updated-page">
+<article class="kb-page updated-page">
   <div class="preview-label"><span class="pill update">Update</span> Updated page preview with diff</div>
   <div class="breadcrumb">{{page_path}}</div>
   <div class="page-icon">{{icon_or_initial}}</div>
@@ -347,32 +401,123 @@ Use this shape:
     <thead><tr><th>Property</th><th>Current</th><th>Proposed</th></tr></thead>
     <tbody>...</tbody>
   </table>
-  <div class="block diff-context">Unchanged surrounding context...</div>
-  <div class="block diff-del">Removed or replaced text...</div>
-  <div class="block diff-add">Added or replacement text...</div>
-  <div class="block diff-context">Unchanged surrounding context...</div>
+  <h2>Exact before</h2>
+  <div class="block">{{complete exact affected section before}}</div>
+  <h2>Exact after</h2>
+  <div class="block">{{complete exact affected section after}}</div>
+  <details open>
+    <summary>Inline diff</summary>
+    <div class="block diff-context">{{literal unchanged context}}</div>
+    <div class="block diff-del">{{literal removed or replaced text}}</div>
+    <div class="block diff-add">{{literal added or replacement text}}</div>
+  </details>
 </article>
 ```
 
-Show enough unchanged context to make placement obvious, but keep it compact. If the update is an append, show the existing ending as context and the appended block as `diff-add`. If the update replaces a section, show the old section as `diff-del` and the final section as `diff-add`.
+Show the complete affected section before and after. Surround it with only enough
+unchanged page context to make placement unambiguous. If the approved action
+deletes anything, repeat it in a deletion ledger with its stable identity or exact
+location, destination for any migrated content, inbound-link treatment, recovery
+path, and quality-gate result.
+
+### Semantic Decisions
+
+For every affected knowledge unit, show:
+
+- source-assertion identity;
+- page Type and Ownership, including canonical owner or Adapter link;
+- stable Kind ID and displayed heading or registered provider mapping;
+- current Maturity, proposed post-approval Maturity, and decision evidence;
+- disposition: preserve, merge, replace, append, delete, reject, or omit;
+- retention reason and next action for retained Raw knowledge.
+
+Do not collapse Type, Ownership, Maturity, and Kind into one field. Do not present
+new intake as already Stable before approval; label it as the proposed
+post-approval state.
+
+### Revision Evidence
+
+For every mutation, show the source, actor, `captured_at`, affected owner, prior
+revision identity, proposed or expected revision identity, and exact diff. Include
+`observed_at` for every changed State and any `event_at`, `valid_from`, or
+`valid_until` that changes interpretation. Name each `supersedes`, `revises`, or
+`invalidates` relation and the provider location that will retain the evidence.
+
+The temporary HTML file is not durable provenance by itself. If the provider has
+no verified way to retain and link the required Revision Evidence after approval,
+show that as a blocker.
+
+### Source Assertion Coverage
+
+Map every durable intake assertion to its exact proposed result. The ledger must
+also show transcript material, unsupported assertions, duplicates, and other
+candidates that were rejected or omitted, with a reason. This is how the reviewer
+checks coverage and material omission; it does not enter final KB prose by
+default.
+
+### Semantic Quality Gate
+
+Show this section visibly or in an open toggle. Separate deterministic checks from
+semantic judgments. Include one row for each required check: Ownership, Coverage,
+Preservation, Faithfulness, Duplication and contradiction, Kind and semantic
+force, Time and provenance, and Deletion safety.
+
+Each row must include:
+
+- category: deterministic or semantic judgment;
+- status: `Pass`, `Flag`, `Not checked`, or `Not applicable`;
+- exact checked scope;
+- concrete evidence;
+- blocking: yes or no, with reason.
+
+A bare status is invalid. Approval is not evidence. Unresolved Ownership,
+contradiction, material omission, unsupported assertion, or unsafe deletion must
+be blocking whether its status is `Flag` or `Not checked`.
+
+### Blockers
+
+If any blocking risk exists, put it in a prominent section and set the page status
+to `Blocked - not approvable`. Name the missing decision, read, relation, or
+evidence that would resolve it. The Questions section asks only for that input and
+must not include the apply question.
+
+If no blocking risk exists, state `No blocking risks found in the checked scope`.
+Do not imply that unchecked external state was proven safe.
+
+### Read-Back Verification Plan
+
+For each proposed mutation, list the exact stable identity, parent, properties,
+relations, full content, deletion outcome, and Revision Evidence fields that will
+be fetched and compared after application. If a provider operation cannot be read
+back, mark it as a blocker before approval rather than promising unverified
+success.
 
 ### Workspace Read
 
 Keep evidence behind a toggle or visually secondary section:
 
 - broad searches and exact searches
-- databases and pages fetched
+- databases, pages, complete affected sections, and revision identities fetched
+- linked owners and inbound or outbound relations inspected
 - nearby examples used to infer conventions
-- placement conclusion
+- inaccessible, partial, or stale reads
+- owner and placement conclusion
 
-This is approval evidence only. Do not copy it into the final Notion body.
+This is approval evidence only. Do not copy it into the final KB body.
 
 ### Skipped
 
-List candidate writes that were considered and skipped, with the reason. Keep this behind a toggle unless it contains a blocker.
+List no-ops and candidate writes that were considered and skipped, with the reason
+and source-assertion identities they cover. Keep this behind a toggle unless it
+contains a blocker.
 
 ### Questions
 
-Ask only for blockers that prevent a correct write. If there are no blockers, ask: "Should I apply these exact KB writes now?"
+Ask only for blockers that prevent a correct write. If any exists, do not ask for
+application. If there are no blockers, ask exactly: "Should I apply these exact KB
+writes now?"
 
-Approval must be fresh and explicit after the latest draft. If the user asks a follow-up, corrects placement, or points to a different convention after approval, regenerate the draft and ask again before writing to the KB.
+Approval must be fresh and explicit after the latest identified draft. If the user
+asks a follow-up or changes any target, content, property, relation, deletion,
+semantic decision, quality-gate result, or operation order, regenerate the draft
+and ask again before writing to the KB.

--- a/cfg/home/agents/skills/capture/SKILL.md
+++ b/cfg/home/agents/skills/capture/SKILL.md
@@ -17,6 +17,58 @@ The semantic-authoring contract in `kb-infra` is normative; this workflow applie
 its Type, Ownership, Maturity, Kind, Revision Evidence, reconciliation, and
 Semantic Quality Gate rules end to end.
 
+## Runtime Semantic Reference
+
+Apply these materialized rules without assuming the `kb-infra` checkout is
+available at run time:
+
+1. Keep one canonical owner per meaning; link or reconcile instead of copying.
+2. Prefer the shortest wording that preserves meaning, scope, qualifiers, time,
+   uncertainty, rationale, and evidence.
+3. Make semantics explicit enough for an agent to parse and natural enough for a
+   person to browse.
+4. Keep Type, Ownership, Maturity, and Kind independent. Type is provider- or
+   domain-defined. Ownership is `Canonical`, `Adapter`, or the blocking migration
+   state `Unresolved`. Maturity is `Raw`, `Developing`, or `Stable`.
+
+Use version 1 of this Kind registry. The ID is stable; the display heading may use
+the preferred heading or a registered alias.
+
+| ID | Kind | Required semantic force |
+| --- | --- | --- |
+| `state` | State | A verified current condition. Use an explicit subject and current-condition verb; retain `observed_at` and show `as of` when volatility changes interpretation. |
+| `direction` | Direction | An aim or exploration, not a settled choice. Use language such as `aims to`, `is intended to`, or `is exploring`. |
+| `decision` | Decision | A selected option or commitment. State the choice before rationale and alternatives. |
+| `rule` | Rule | A scoped norm. `must` has no exception, `should` is the default with justified exceptions, and `may` grants permission. |
+| `preference` | Preference | What a named subject favors or avoids, including strength when material. |
+| `procedure` | Procedure | Ordered actions with an observable outcome. Use imperative steps. |
+| `event` | Event | Something that happened. Use past tense and an absolute date when known. |
+| `evidence` | Evidence | Material supporting or qualifying a claim, with provenance. |
+| `open-item` | Open item | An unresolved question or outcome requiring follow-up. Phrase it directly. |
+| `schema` | Schema | A reusable shape, field contract, or controlled vocabulary. |
+| `example` | Example | A concrete illustration that does not itself define the rule. |
+| `citation` | Citation | An external source reference with enough identity to retrieve it. |
+
+Keep one canonical subject per page, one dominant Kind per section, and one primary
+claim, instruction, or question per knowledge unit. Put a one-sentence description
+first, current or actionable content before supporting history and evidence, and
+Open items and Citations last. Claim-to-qualifier, rationale, and evidence adjacency
+overrides that order. Do not create universal page profiles, empty sections, or
+decorative structure.
+
+Choose the least complex presentation that preserves semantic relationships:
+short prose for one assertion or tightly coupled explanation; parallel bullets for
+two or more unordered peers; numbers for ordered or ranked items; labelled entries
+for term-definition pairs; and tables only for repeated comparable records. Keep
+examples separate from their governing rule and number external Citations when
+inline correspondence would otherwise be unclear.
+
+Use one canonical term per concept, with aliases stored at its owner for retrieval.
+Expand uncommon abbreviations and flag uncertain equivalence instead of silently
+merging concepts. Never use relative time without an absolute anchor. Distinguish
+`observed_at`, `event_at`, optional `valid_from` or `valid_until`, and apply-time
+`captured_at`; never substitute one for another.
+
 ## Loop
 
 ### 1. Map The Live KB
@@ -91,8 +143,9 @@ Reconcile the Active Canonical View instead of appending a session summary.
 - Remove superseded wording in the same proposed write.
 - Keep one dominant Kind per section and the least complex presentation that
   preserves the relationships among assertions.
-- Preserve Revision Evidence for every mutation: source, actor, `captured_at`,
-  affected owner, prior and proposed revision identity, exact diff, and any
+- Preserve Revision Evidence for every mutation: source, actor, the provider field
+  or deterministic operation that will assign `captured_at` when the accepted
+  mutation is applied, affected owner, prior and proposed revision identity, exact diff, and any
   `supersedes`, `revises`, or `invalidates` relation. A changed State also retains
   its distinct `observed_at`.
 - Before deleting a block or page, account for unique durable content, inbound
@@ -124,8 +177,9 @@ At minimum, report:
 - Deletion safety: unique content, inbound links, replacement owner, and recovery
   path checked for each deletion.
 
-Any unresolved Ownership, contradiction, material omission, unsupported
-assertion, or unsafe deletion is a blocking risk. A blocking `Flag` or
+Any unresolved Ownership, contradiction, material omission, unsupported assertion
+retained or introduced in the proposed after-state, or unsafe deletion is a
+blocking risk. A blocking `Flag` or
 `Not checked` result stops the write: the draft must identify the missing decision
 or evidence and must not ask for approval to apply it. Other flags remain visible
 for informed approval; approval never converts a failed check into a pass.
@@ -150,8 +204,9 @@ It must include:
   locate it, and an explicit deletion ledger;
 - semantic decisions: Ownership, stable Kind ID, current and proposed Maturity,
   and evidence for each decision;
-- Revision Evidence: source, actor, capture time, affected owner, revision
-  identities, semantic change relations, exact diff, and evidence destination;
+- Revision Evidence: source, actor, exact `captured_at` field or apply-time
+  derivation, affected owner, revision identities, semantic change relations,
+  exact diff, and evidence destination;
 - Semantic Quality Gate: all required checks, status, checked scope, evidence,
   and whether a finding blocks the write;
 - skipped writes and no-ops: considered targets or conventions not selected;

--- a/cfg/home/agents/skills/capture/SKILL.md
+++ b/cfg/home/agents/skills/capture/SKILL.md
@@ -8,81 +8,207 @@ description: Capture completed conversations or agent sessions into the Knowledg
 ## Invariant
 
 Every run produces an HTML approval draft before any KB write. There is no
-inline-chat approval shortcut, even for tiny updates.
+inline-chat approval shortcut, even for tiny updates. Human approval authorizes
+an exact write; it is not evidence that the write is semantically correct.
+
+The Knowledge Bank is the source of truth. Apply its live provider through the
+available connector without hardcoding provider-specific fields or operations.
+The semantic-authoring contract in `kb-infra` is normative; this workflow applies
+its Type, Ownership, Maturity, Kind, Revision Evidence, reconciliation, and
+Semantic Quality Gate rules end to end.
 
 ## Loop
 
-### 1. Map Live KB
+### 1. Map The Live KB
 
 Read the live KB through its provider connector before choosing a target.
 
 - Search broad parent areas, likely databases, sibling pages, repo/project
-  aliases, and relevant conventions.
-- Search exact names, URLs, repository slugs, and likely page titles.
-- Fetch the likely target and nearby examples before proposing fields or body
-  shape.
+  aliases, relevant conventions, and possible competing owners.
+- Search exact names, URLs, repository slugs, stable page IDs, and likely titles.
+- Fetch each likely owner, the complete affected sections, linked owners, inbound
+  relations needed for deletion safety, and nearby examples before proposing
+  fields or body shape.
+- Discover how the provider represents Type, Ownership, Maturity, Kind, stable
+  page identity, revisions, relations, and deletion recovery. Do not invent a
+  field when the live schema uses another representation.
 - Prefer live KB structure over repo assumptions or stale local artifacts.
 
-Completion criterion: the proposed target, placement, property schema, and
-nearby page pattern are grounded in live KB reads, or the draft states that live
-verification was unavailable.
+If a complete affected section, a possible competing owner, or required relation
+cannot be read, record the gap as `Not checked`. When that gap could hide an
+ownership, contradiction, omission, unsupported-assertion, or deletion risk, it
+blocks the write.
 
-### 2. Distill Durable Knowledge
+Completion criterion: the proposed owner, placement, property schema, affected
+content, linked owners, and Revision Evidence mechanism are grounded in live KB
+reads. Otherwise the run may produce an unverified draft, but it cannot offer or
+apply the write.
 
-Extract only what belongs in the Knowledge Bank.
+### 2. Turn Intake Into Semantic Candidates
 
-- Keep progress, decisions, rationale, open tasks, blockers, follow-ups, repo
-  links, issue/PR links, commits, and durable user preferences.
-- Exclude transcript framing, agent provenance, temporary command noise, and
-  facts not meant to survive the session.
-- If a convention applies beyond the immediate project, draft the higher-level
-  update separately from the project-specific update.
-- Keep final KB prose source-free unless provenance is itself useful knowledge.
+Treat every incoming assertion as `Raw` before editorial processing. Build a
+source-assertion ledger and keep it in the approval artifact, not in the final KB
+prose unless provenance changes how the knowledge should be interpreted.
 
-Completion criterion: every proposed KB body reads as durable knowledge, not as a
-session log.
+For every assertion:
 
-### 3. Draft Exact Writes
+1. Preserve the subject, meaning, scope, qualifiers, uncertainty, temporal
+   meaning, rationale, and supporting evidence.
+2. Classify it with a stable Kind ID from the versioned registry. Use explicit
+   Kind metadata or a registered provider mapping; never infer Kind from an
+   arbitrary heading.
+3. Identify the candidate canonical owner and any Adapter that should link to it.
+4. Mark the proposed disposition as preserve, merge, replace, append, delete,
+   reject, or omit, with a reason.
+5. Propose the post-approval Maturity and record the evidence for that decision:
+   - `Stable` only when the assertion is reconciled, sufficiently supported, and
+     safe to reuse after approval;
+   - `Developing` when it is reconciled and useful but explicitly unsettled or
+     expected to change;
+   - retained `Raw` only when the draft names its owner, provenance, retention
+     reason, and next review or distillation action.
+
+Exclude transcript framing, temporary command noise, and unsupported claims.
+Keep durable progress, decisions, rationale, open items, blockers, follow-ups,
+links, and preferences only when they pass reconciliation. If a convention applies
+beyond the immediate project, treat the higher-level meaning as a separate
+candidate with its own owner instead of copying it into both places.
+
+Completion criterion: every source assertion maps to a proposed disposition,
+Kind, Maturity, owner, provenance, and evidence, including rejected or omitted
+assertions.
+
+### 3. Reconcile Canonical Meaning
+
+Reconcile the Active Canonical View instead of appending a session summary.
+
+- Compare each candidate with the complete affected section and linked owners.
+- Establish one canonical owner per meaning. An Adapter links to that owner and
+  never silently becomes a second owner. `Unresolved` Ownership blocks the write.
+- Preserve, merge, replace, or delete every affected meaning deliberately.
+- Rewrite the smallest coherent section that expresses the resulting meaning.
+- Append only a genuine chronological Event or a new peer in an existing set.
+- Remove superseded wording in the same proposed write.
+- Keep one dominant Kind per section and the least complex presentation that
+  preserves the relationships among assertions.
+- Preserve Revision Evidence for every mutation: source, actor, `captured_at`,
+  affected owner, prior and proposed revision identity, exact diff, and any
+  `supersedes`, `revises`, or `invalidates` relation. A changed State also retains
+  its distinct `observed_at`.
+- Before deleting a block or page, account for unique durable content, inbound
+  links, replacement owners, and the recovery path.
+
+Completion criterion: the proposal is the smallest non-duplicative change that
+preserves current meaning and recoverable history; append-only accretion is used
+only when its semantics require it.
+
+### 4. Run The Semantic Quality Gate
+
+Run the gate before presenting anything as approvable. Separate deterministic
+checks from semantic judgments. Every result must be `Pass`, `Flag`,
+`Not checked`, or `Not applicable` and name both the checked scope and concrete
+evidence; a bare status is invalid.
+
+At minimum, report:
+
+- Ownership: owner checked, competing owners considered, and Adapter links named.
+- Coverage: every source assertion mapped to preserved, changed, omitted, or
+  rejected content.
+- Preservation: qualifiers, uncertainty, time, rationale, and unique durable
+  content accounted for.
+- Faithfulness: every proposed claim traced to its source without unsupported
+  strengthening.
+- Duplication and contradiction: affected sections and linked owners compared.
+- Kind and semantic force: stable Kind ID and Kind-specific constraints checked.
+- Time and provenance: temporal anchors and complete Revision Evidence present.
+- Deletion safety: unique content, inbound links, replacement owner, and recovery
+  path checked for each deletion.
+
+Any unresolved Ownership, contradiction, material omission, unsupported
+assertion, or unsafe deletion is a blocking risk. A blocking `Flag` or
+`Not checked` result stops the write: the draft must identify the missing decision
+or evidence and must not ask for approval to apply it. Other flags remain visible
+for informed approval; approval never converts a failed check into a pass.
+
+Completion criterion: each proposed mutation has evidence-bearing results for all
+required checks, with blocking and non-blocking findings distinguished.
+
+### 5. Draft Exact Writes
 
 Create a provider-like HTML approval draft using [HTML-DRAFT.md](HTML-DRAFT.md).
+The draft is an approval artifact, not a second knowledge record.
 
-The draft must include:
+It must include:
 
-- workspace read: searches, pages, databases, and examples inspected
-- proposed results: page previews for each create or update
-- body preview: exact source-free final body, with inline diffs for updates
-- skipped writes: considered targets or conventions not selected
-- questions: only blockers that prevent a correct write
+- workspace read: searches, pages, databases, revisions, relations, and examples
+  inspected, including inaccessible or partial reads;
+- source-assertion ledger: exact intake-to-result coverage, including omissions
+  and rejections;
+- proposed results: exact provider-visible actions in application order, with
+  target stable IDs, placement, properties, relations, and final content;
+- exact before and after content for every update, enough unchanged context to
+  locate it, and an explicit deletion ledger;
+- semantic decisions: Ownership, stable Kind ID, current and proposed Maturity,
+  and evidence for each decision;
+- Revision Evidence: source, actor, capture time, affected owner, revision
+  identities, semantic change relations, exact diff, and evidence destination;
+- Semantic Quality Gate: all required checks, status, checked scope, evidence,
+  and whether a finding blocks the write;
+- skipped writes and no-ops: considered targets or conventions not selected;
+- read-back plan: exact properties, relations, content, deletion results, and
+  revision identity that will be compared after applying;
+- questions: only blockers that prevent a correct write.
+
+The before and after views are the approval boundary. Do not hide content behind
+summaries, ellipses, placeholders, or implementation notes. Render the exact
+provider representation that will exist after approval, including explicit Kind
+or registered mapping and Maturity representation.
 
 Write the draft to the OS temp directory, open it for the user, and report the
-absolute path in chat.
+absolute path in chat. If any blocking risk remains, label the draft blocked and
+ask only the question needed to resolve it. Otherwise ask exactly: "Should I apply
+these exact KB writes now?"
 
-Completion criterion: the user can approve or reject the exact KB writes from the
-HTML file without needing hidden context from the conversation.
+Completion criterion: the user can evaluate the semantic decisions and approve or
+reject the exact KB mutations from the HTML file without hidden conversation
+context.
 
-### 4. Ask For Fresh Approval
+### 6. Ask For Fresh Approval
 
-Ask: "Should I apply these exact KB writes now?"
+Only an unambiguous affirmative answer to "Should I apply these exact KB writes
+now?" or an equally explicit instruction to apply the latest named draft authorizes
+writing. "Looks good", clarifying answers, placement discussion, or approval of an
+earlier draft do not.
 
-Only explicit approval after the latest draft permits writing. "Looks good",
-clarifying answers, or placement discussion are not approval. If the conversation
-changes the draft, regenerate the HTML file and ask again.
+If the conversation changes any target, content, property, relation, action,
+deletion, order, semantic decision, Revision Evidence, or quality-gate result,
+regenerate the HTML file and ask again. A blocked draft cannot be approved for
+application.
 
 Completion criterion: approval is explicit, fresh, and applies to the latest
-exact draft.
+unblocked exact draft.
 
-### 5. Apply And Verify
+### 7. Apply Exactly And Read Back
 
-Apply only the approved writes.
+Immediately before writing, re-read every target's current revision and the
+relations needed for deletion safety. If anything differs from the approved
+before-state, stop, reconcile again, regenerate the draft, and obtain fresh
+approval.
 
-- Use the live schema and exact properties from the approved draft.
-- Preserve child pages, databases, and unrelated content unless the draft
-  explicitly says otherwise.
-- Read back every updated KB item.
-- Report what changed and what remains unresolved.
+Apply only the approved actions, in the approved order, through the bound provider
+connector. Use the exact properties, relations, content, and deletions shown in the
+draft, and retain the approved Revision Evidence. Do not substitute a nearby
+provider operation; if an exact action is unavailable, stop and report it.
 
-Completion criterion: every approved write has been read back from the KB, or any
-failed write is reported with the exact blocker.
+After applying, read back every affected item and revision from the KB. Compare the
+result with the approved after-state: stable identity, parent, properties,
+relations, full content, deletion outcome, and Revision Evidence. Report exact
+matches, mismatches, and partial failures. Never silently repair a mismatch;
+another mutation requires a new exact draft and fresh approval.
+
+Completion criterion: every approved mutation either matches its read-back exactly
+or is reported with the precise mismatch or provider blocker. No unapproved
+corrective write occurs.
 
 ## Placement Rules
 
@@ -90,17 +216,17 @@ failed write is reported with the exact blocker.
 - Put dense backlog, references, reflections, lessons, quotes, evidence, and long
   decision context in child pages under the relevant parent.
 - Prefer the smallest coherent set of writes over broad context dumps.
-- Choose one canonical owner for each fact, chapter, or lesson; other pages link
-  to that owner.
+- Choose one canonical owner for each meaning; other pages link to that owner.
 - Never invent a page or database when an existing owner can be strengthened.
 
 ## Safety Rules
 
-The Invariant above is the single gate: nothing is written, edited, appended,
-related, moved, renamed, archived, or deleted in the KB before explicit approval
-of the latest exact draft.
+The Invariant above is the single authorization gate: nothing is written, edited,
+appended, related, moved, renamed, archived, or deleted in the KB before explicit
+approval of the latest unblocked exact draft.
 
-- The KB is the source of truth.
-- Never invent facts to fit a field.
+- Never invent facts, provider fields, relations, revision support, or evidence.
 - Treat KB writes as hard to version and potentially destructive.
-- If KB access is unavailable, produce only a draft and label it unverified.
+- Keep provider-specific bindings and personal values out of the committed skill.
+- If live KB access is unavailable, produce only a blocked, unverified draft.
+- Do not use a live KB write to develop, test, or validate this workflow.


### PR DESCRIPTION
## Summary

- Materialize the completed semantic Capture reconciliation from [`giacomoguidotto/kb-infra#9`](https://github.com/giacomoguidotto/kb-infra/pull/9).
- Keep the workspace-managed `SKILL.md` and `HTML-DRAFT.md` byte-identical to the `kb-infra` source.
- Make the end-to-end Capture workflow available through the existing workspace skill wiring after merge.

## Why

`kb-infra` is the provider-agnostic specification, while this repository owns the versioned workspace copy used by the local agent harness. The repositories therefore need separate, corresponding commits and PRs for the Capture change.

## Verification

- `git diff --check main...HEAD`
- `cmp -s` confirmed both Capture files are byte-identical to the `kb-infra` branch
- The `kb-infra` repository specification check passed
- The approval-draft HTML scaffold parsed successfully
- Independent Standards and Spec reviews passed with 0 remaining findings
- The isolated workspace branch is clean
- The unrelated `cfg/xdg/zed/settings.json` change in the main workspace checkout was not touched, staged, or included

## Upstream specification

- Ready PR: [`giacomoguidotto/kb-infra#9`](https://github.com/giacomoguidotto/kb-infra/pull/9)
- Issue: [`giacomoguidotto/kb-infra#2`](https://github.com/giacomoguidotto/kb-infra/issues/2)
