### PR TITLE
Materialize Capture approval review

### DIFF
--- a/cfg/home/agents/skills/capture/HTML-DRAFT.md
+++ b/cfg/home/agents/skills/capture/HTML-DRAFT.md
@@ -14,20 +14,85 @@ Resolve the temp directory from `$TMPDIR`, falling back to `/tmp` on Unix or `%T
 
 Open the file for the user and report the absolute path in chat.
 
+## Contents
+
+- [Design Goal](#design-goal)
+- [Reviewability Contract](#reviewability-contract)
+- [Scaffold](#scaffold)
+- [Required Sections](#required-sections)
+  - [Proposed Results](#proposed-results)
+  - [Semantic Decisions](#semantic-decisions)
+  - [Revision Evidence](#revision-evidence)
+  - [Semantic Quality Gate](#semantic-quality-gate)
+  - [Reviewability Validation](#reviewability-validation)
+  - [Blockers](#blockers)
+  - [Read-Back Verification Plan](#read-back-verification-plan)
+  - [Workspace Read](#workspace-read)
+  - [Skipped](#skipped)
+  - [Questions](#questions)
+
 ## Design Goal
 
-Make the draft feel like a deep preview of the final result inside the bound KB
-provider, not a generic report. Exact before and after content, semantic decisions,
-deletions, Revision Evidence, and quality-gate evidence are part of the approval
-surface rather than hidden implementation detail.
+Make the draft a human review interface for an exact provider change. The visible
+surface should feel like the bound KB provider and answer three questions without
+requiring technical inspection: **what changes, where, and what will exist after
+approval?**
 
-- Use a Notion-dark palette, Notion-like spacing, page typography, property rows, toggles, callouts, and database/table previews.
-- Render each proposed write as a provider-like KB page preview.
-- For new pages, show a "New page preview" that resembles the page that would exist after approval.
-- For page updates, show complete exact before and after views plus an inline diff
-  in the same KB page shell.
-- Put proposed results first. Keep source mapping and workspace-read evidence
-  available but visually secondary. Keep blockers and deletion risk prominent.
+Use two co-located layers:
+
+- The **review layer** is primary. It uses ordinary language, provider-like property
+  tables, rendered page content, and literal inline diffs. It shows every changed
+  field, relation, block, and deletion while summarizing unchanged context.
+- The **exact evidence layer** is secondary. It retains complete serialized
+  before/after states, stable provider IDs, exact tool inputs, transition JSON, and
+  validator reports inside collapsed `technical-evidence` toggles.
+
+The layers must be losslessly equivalent: every approved change appears in both,
+and every exact-evidence mutation appears in the review layer. Exactness belongs in
+the artifact; raw serialization does not become the interface.
+
+Use a Notion-dark palette, Notion-like spacing, page typography, property rows,
+toggles, callouts, and database/table previews. Put proposed results first. Keep
+source mapping, complete raw state, and workspace-read evidence visually secondary.
+Keep blockers and deletion risk prominent.
+
+## Reviewability Contract
+
+The draft passes reviewability only when a reviewer can keep every technical-
+evidence toggle closed and still enumerate the complete write set.
+
+The left sidebar is the ordered mutation outline. Generate one labelled anchor per
+mutation, grouped by operation stage or kind, and point it at that mutation card's
+HTML `id`. Outline targets must match the mutation sequence exactly: every card
+appears once, in application order, with no extra target.
+
+For every mutation:
+
+1. Start with a one-sentence plain-language outcome under `What changes`.
+2. Show the human name and provider location first. Put the stable ID on a muted
+   secondary line that remains copyable.
+3. Render every added, removed, renamed, or changed property or relation as one row
+   in a `change-table`. Use the columns `Field`, `Action`, `Current`, `Proposed`,
+   and `Meaning` unless the provider has a clearer native equivalent.
+4. Render the complete final page or affected section in `provider-preview`. For
+   content updates, also show a literal human-readable diff with enough unchanged
+   context to locate it.
+5. State unchanged scope compactly: name the preserved body, relation values,
+   views, or properties, and give an exact count or complete readable list where
+   that helps the decision.
+6. Put complete serialized provider inputs and states exclusively inside a closed
+   `details.technical-evidence` element. Label its before and after containers with
+   `data-exact-before` and `data-exact-after`. Mark serialized blocks with
+   `data-raw-provider-state`.
+
+For repeated identical mutations, show one shared change set plus a target matrix.
+Each mutation still gets its own stable identity, application position, and exact
+evidence. Any target-specific difference gets its own visible row instead of being
+folded into the shared summary.
+
+The human-readable review layer is complete, not approximate. Summaries may replace
+unchanged raw state; they may not replace a changed value, option, default,
+relation target, deletion, or final content block.
 
 ## Scaffold
 
@@ -74,6 +139,10 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
         min-height: 100vh;
       }
       .sidebar {
+        position: sticky;
+        top: 0;
+        height: 100vh;
+        overflow-y: auto;
         border-right: 1px solid var(--line);
         background: #171717;
         padding: 18px 14px;
@@ -88,6 +157,26 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
         border-radius: 6px;
         padding: 6px 8px;
       }
+      .outline-group { margin-top: 16px; }
+      .outline-label {
+        color: var(--faint);
+        font-size: 11px;
+        font-weight: 650;
+        letter-spacing: 0.06em;
+        padding: 0 8px 5px;
+        text-transform: uppercase;
+      }
+      .outline-card {
+        display: grid;
+        grid-template-columns: 24px minmax(0, 1fr);
+        gap: 6px;
+        color: var(--muted);
+        text-decoration: none;
+        border-radius: 6px;
+        padding: 6px 8px;
+      }
+      .outline-card:hover { background: var(--surface); color: var(--text); }
+      .outline-index { color: var(--faint); font-variant-numeric: tabular-nums; }
       main {
         max-width: 980px;
         width: 100%;
@@ -165,12 +254,17 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
       .pill.blocked { background: var(--red-bg); color: #ffb2ac; }
       .pill.flag { background: var(--yellow-bg); color: #f2c96d; }
       .kb-page {
+        scroll-margin-top: 24px;
         background: var(--page-bg);
         border: 1px solid var(--line);
         border-radius: 8px;
         padding: 34px 42px 42px;
         margin: 18px 0 26px;
         box-shadow: 0 24px 80px rgba(0, 0, 0, 0.20);
+      }
+      .kb-page:target {
+        border-color: var(--blue);
+        box-shadow: 0 0 0 2px var(--blue-bg), 0 24px 80px rgba(0, 0, 0, 0.20);
       }
       .preview-label {
         color: var(--muted);
@@ -255,12 +349,56 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
       .diff-context {
         color: var(--muted);
       }
-      .property-diff td:nth-child(2) {
+      .property-diff td:nth-child(3) {
         color: #ffb2ac;
         text-decoration: line-through;
       }
-      .property-diff td:nth-child(3) {
+      .property-diff td:nth-child(4) {
         color: #93d5a6;
+      }
+      .change-summary {
+        border-left: 3px solid var(--blue);
+        background: var(--blue-bg);
+        border-radius: 6px;
+        padding: 14px 16px;
+        margin: 18px 0;
+      }
+      .change-summary h2 {
+        margin: 0 0 6px;
+        font-size: 18px;
+      }
+      .target-id {
+        color: var(--faint);
+        font-size: 12px;
+        overflow-wrap: anywhere;
+      }
+      .change-table .action-add { color: #93d5a6; }
+      .change-table .action-change { color: #f2c96d; }
+      .change-table .action-remove { color: #ffb2ac; }
+      .provider-preview {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--surface);
+        padding: 18px 20px;
+        margin: 18px 0;
+      }
+      .unchanged-scope {
+        color: var(--muted);
+        font-size: 13px;
+        margin: 12px 0;
+      }
+      details.technical-evidence {
+        margin-top: 20px;
+        color: var(--muted);
+      }
+      details.technical-evidence pre {
+        max-height: 460px;
+        overflow: auto;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #171717;
+        padding: 12px;
+        font-size: 12px;
       }
       .approval-question {
         border: 1px solid var(--line-strong);
@@ -283,12 +421,21 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
       }
     </style>
   </head>
-  <body>
+  <body data-capture-draft-version="1" data-draft-id="{{draft_id}}">
     <div class="app">
       <aside class="sidebar">
         <div class="sidebar-title">Knowledge draft</div>
         <div class="sidebar-item">Approval needed</div>
         <div class="sidebar-item">{{write_count}} proposed writes</div>
+        <nav class="mutation-outline" aria-label="Proposed write outline">
+          <div class="outline-group">
+            <div class="outline-label">{{operation_group}}</div>
+            <a class="outline-card" data-mutation-link href="#{{mutation_id}}">
+              <span class="outline-index">{{operation_index}}</span>
+              <span>{{human_target_name}}</span>
+            </a>
+          </div>
+        </nav>
       </aside>
       <main>
         <div class="breadcrumb">Knowledge Bank / Drafts / {{topic}}</div>
@@ -302,7 +449,26 @@ Use inline CSS. Do not depend on Tailwind, remote fonts, scripts, or external as
           <div class="property-row"><strong>Requires</strong><span>Fresh explicit approval</span></div>
         </div>
 
-        <section id="proposed-results">...</section>
+        <section id="proposed-results">
+          <section class="batch-overview">...</section>
+          <article id="{{mutation_id}}" class="kb-page mutation" data-mutation-id="{{mutation_id}}" data-mutation-kind="{{mutation_kind}}">
+            <div class="preview-label"><span class="pill update">Update</span> {{human_target_name}}</div>
+            <div class="target-id">{{stable_target_id}}</div>
+            <section class="change-summary">
+              <h2>What changes</h2>
+              <p>{{one_sentence_outcome}}</p>
+            </section>
+            <table class="change-table">...</table>
+            <section class="provider-preview">{{complete_human_readable_after_state}}</section>
+            <p class="unchanged-scope">{{exact_preserved_scope_summary}}</p>
+            <details class="technical-evidence">
+              <summary>Exact provider evidence</summary>
+              <section data-exact-before>...</section>
+              <section data-exact-after>...</section>
+              <pre data-raw-provider-state>...</pre>
+            </details>
+          </article>
+        </section>
         <section id="semantic-decisions">...</section>
         <section id="revision-evidence">...</section>
         <details id="source-assertions"><summary>Source assertion coverage</summary>...</details>
@@ -326,29 +492,49 @@ approvable` and the `blocked` pill class. Use `draft_id` to make later approval
 refer to this exact artifact; do not reuse it after any content or gate result
 changes.
 
+Before opening the file, run `scripts/validate-approval-draft.py` from the installed
+Capture skill. Open only a `Pass` result. The validator checks structural
+reviewability; it does not prove semantic correctness or grant approval.
+
 ## Required Sections
 
 ### Proposed Results
 
-Put proposed results first in exact application order. Use one provider-like KB page
-preview per mutation. The sequence and preview together define what approval
-authorizes.
+Put proposed results first. Start with a batch overview that names the outcome,
+operation count, shared change sets, and affected human-readable targets. Then show
+the mutations in exact application order. Use one provider-like KB preview per
+mutation; identical repeated changes may point to one visible shared change set.
+The sequence, visible change rows, and exact evidence together define what approval
+authorizes. Build the sidebar outline from this same ordered sequence according to
+the Reviewability Contract.
 
 Each preview must include:
 
-- target database or page name plus stable ID or URL;
-- action: create, update, append, relate, move, rename, archive, or delete;
-- parent and exact block or section placement;
-- exact current and proposed property values from the live schema;
-- exact current and proposed relations, including canonical-owner links;
-- full final page or block body, without placeholders or ellipses;
-- each deleted property, relation, block, section, or page;
-- expected resulting revision identity when the provider can predict it; otherwise
-  the exact revision field that read-back must discover and verify.
+- a plain-language `What changes` outcome;
+- target database or page name first, with stable ID or URL as secondary copyable
+  detail;
+- action and exact application position;
+- one `change-table` row for every changed property, option, default, relation,
+  block, move, rename, archive, or deletion;
+- exact current and proposed values in readable provider terms, including
+  canonical-owner links and relation targets by name;
+- a `provider-preview` containing the complete final page, block, or affected
+  section without placeholders or ellipses;
+- an `unchanged-scope` statement accounting for preserved content and schema;
+- expected resulting revision identity when predictable, or the exact revision
+  field read-back will discover;
+- a closed `technical-evidence` toggle with complete exact provider input,
+  before/after state, stable IDs, transition JSON, validator report, and rollback.
 
-No-op candidates belong under Skipped, not in the mutation sequence. Do not use
-generic cards as the main preview. Cards are acceptable only inside the page shell
-when a database or table is the provider's natural final representation.
+For database schema mutations, the visible change table has one row per field and
+uses readable types, allowed values, defaults, relation targets, and semantic
+meaning. Show existing unchanged fields as an exact count plus readable name list;
+the complete serialized schema belongs in technical evidence.
+
+No-op candidates belong under Skipped, not in the mutation sequence. Use the bound
+provider's natural representation as the main preview. Generic cards and serialized
+objects belong only in secondary evidence when they are not the provider's visible
+interface.
 
 ### New Page Preview
 
@@ -359,13 +545,28 @@ stable target does not already exist.
 Use this shape:
 
 ```html
-<article class="kb-page new-page">
+<article id="{{mutation_id}}" class="kb-page mutation new-page" data-mutation-id="{{mutation_id}}" data-mutation-kind="create">
   <div class="preview-label"><span class="pill create">Create</span> New page preview</div>
   <div class="breadcrumb">{{parent_path}}</div>
+  <div class="target-id">{{expected_stable_identity_or_readback_field}}</div>
   <div class="page-icon">{{icon_or_initial}}</div>
   <h1>{{new_page_title}}</h1>
-  <div class="property-table">...</div>
-  <div class="block">{{exact final KB body}}</div>
+  <section class="change-summary">
+    <h2>What changes</h2>
+    <p>{{plain_language_create_outcome}}</p>
+  </section>
+  <table class="change-table">{{one row per created property or relation}}</table>
+  <section class="provider-preview">
+    <div class="property-table">{{exact readable final properties}}</div>
+    <div class="block">{{exact final KB body}}</div>
+  </section>
+  <p class="unchanged-scope">Target absent; no existing content changes.</p>
+  <details class="technical-evidence">
+    <summary>Exact provider evidence</summary>
+    <section data-exact-before>Target absent: {{search scope and evidence}}</section>
+    <section data-exact-after>{{complete exact provider after-state}}</section>
+    <pre data-raw-provider-state>{{exact tool input and transition evidence}}</pre>
+  </details>
 </article>
 ```
 
@@ -388,40 +589,57 @@ before/after structure even when the body is unchanged.
 
 ### Updated Page Preview
 
-For updates, render an "Updated page preview" with complete exact before and after
-content. Add an inline diff for review, but never make the reviewer reconstruct an
-after-state by applying the diff mentally.
+For updates, render an "Updated page preview" whose primary surface is the complete
+readable change set and final provider-visible state. Add a literal inline diff for
+content changes, while keeping the full proposed page or affected section visible
+so the reviewer never reconstructs the after-state mentally.
 
 Use this shape:
 
 ```html
-<article class="kb-page updated-page">
+<article id="{{mutation_id}}" class="kb-page mutation updated-page" data-mutation-id="{{mutation_id}}" data-mutation-kind="update">
   <div class="preview-label"><span class="pill update">Update</span> Updated page preview with diff</div>
   <div class="breadcrumb">{{page_path}}</div>
+  <div class="target-id">{{stable_page_or_data_source_id}}</div>
   <div class="page-icon">{{icon_or_initial}}</div>
   <h1>{{existing_page_title}}</h1>
-  <table class="property-diff">
-    <thead><tr><th>Property</th><th>Current</th><th>Proposed</th></tr></thead>
+  <section class="change-summary">
+    <h2>What changes</h2>
+    <p>{{plain_language_outcome}}</p>
+  </section>
+  <table class="change-table property-diff">
+    <thead><tr><th>Field</th><th>Action</th><th>Current</th><th>Proposed</th><th>Meaning</th></tr></thead>
     <tbody>...</tbody>
   </table>
-  <h2>Exact before</h2>
-  <div class="block">{{complete exact affected section before}}</div>
-  <h2>Exact after</h2>
-  <div class="block">{{complete exact affected section after}}</div>
-  <details open>
-    <summary>Inline diff</summary>
+  <section class="provider-preview">
+    <h2>Result after approval</h2>
+    <div class="block">{{complete exact human-readable affected section after}}</div>
+  </section>
+  <section class="inline-diff">
+    <h2>Content diff</h2>
     <div class="block diff-context">{{literal unchanged context}}</div>
     <div class="block diff-del">{{literal removed or replaced text}}</div>
     <div class="block diff-add">{{literal added or replacement text}}</div>
+  </section>
+  <p class="unchanged-scope">{{exact readable preserved scope}}</p>
+  <details class="technical-evidence">
+    <summary>Exact provider evidence</summary>
+    <section data-exact-before>{{complete exact provider before-state}}</section>
+    <section data-exact-after>{{complete exact provider after-state}}</section>
+    <pre data-raw-provider-state>{{exact tool input, transition JSON, validator report, rollback}}</pre>
   </details>
 </article>
 ```
 
-Show the complete affected section before and after. Surround it with only enough
-unchanged page context to make placement unambiguous. If the approved action
-deletes anything, repeat it in a deletion ledger with its stable identity or exact
-location, destination for any migrated content, inbound-link treatment, recovery
-path, and quality-gate result.
+For body changes, show the complete final affected section and the literal changed
+lines with enough readable context to make placement unambiguous. For property-only
+or schema-only updates, use the field-level change table as the primary diff and
+state the preserved body explicitly. The exact evidence layer retains the complete
+provider before/after state for audit and read-back.
+
+If the approved action deletes anything, repeat it in a deletion ledger with its
+stable identity or exact location, destination for migrated content, inbound-link
+treatment, recovery path, and quality-gate result.
 
 ### Semantic Decisions
 
@@ -440,10 +658,11 @@ post-approval state.
 
 ### Revision Evidence
 
-For every mutation, show the source, actor, the exact provider field or deterministic
-operation that will assign `captured_at` when the accepted mutation is applied,
-the affected owner, prior revision identity, proposed or expected revision
-identity, and exact diff. Include
+For every mutation, show a readable evidence row with the source name, actor,
+provider field or deterministic operation that will assign `captured_at`, affected
+owner name, prior revision, proposed or expected revision, semantic relation, and a
+plain-language change description. Retain the literal exact diff in that mutation's
+collapsed technical evidence. Include
 `observed_at` for every changed State and any `event_at`, `valid_from`, or
 `valid_until` that changes interpretation. Name each `supersedes`, `revises`, or
 `invalidates` relation and the provider location that will retain the evidence.
@@ -483,6 +702,20 @@ in the proposed after-state, or unsafe deletion must be blocking whether its sta
 is `Flag` or `Not checked`. An unsupported candidate that is explicitly rejected or
 omitted may pass Coverage and Faithfulness when the ledger proves it cannot enter
 the approved result.
+
+### Reviewability Validation
+
+Run `python3 scripts/validate-approval-draft.py <draft.html>` before opening the
+artifact. A passing draft has one mutation article per proposed operation; every
+article has a non-empty `change-summary`, at least one readable `change-table` row,
+a non-empty `provider-preview`, an unchanged-scope statement, and a closed
+`technical-evidence` toggle containing exact before/after evidence. Serialized raw
+provider state appears only inside that toggle. Its labelled outline targets every
+mutation exactly once and in application order.
+
+Treat `Block` as an artifact defect: regenerate the draft and rerun validation.
+This structural result remains distinct from the Semantic Quality Gate and never
+authorizes a write.
 
 ### Blockers
 

--- a/cfg/home/agents/skills/capture/SKILL.md
+++ b/cfg/home/agents/skills/capture/SKILL.md
@@ -223,42 +223,41 @@ findings are distinguished.
 Create a provider-like HTML approval draft using [HTML-DRAFT.md](HTML-DRAFT.md).
 The draft is an approval artifact, not a second knowledge record.
 
-It must include:
+Use two layers with one approval meaning:
 
-- workspace read: searches, pages, databases, revisions, relations, and examples
-  inspected, including inaccessible or partial reads;
-- source-assertion ledger: exact intake-to-result coverage, including omissions
-  and rejections;
-- proposed results: exact provider-visible actions in application order, with
-  target stable IDs, placement, properties, relations, and final content;
-- exact before and after content for every update, enough unchanged context to
-  locate it, and an explicit deletion ledger;
-- semantic decisions: Ownership, stable Kind ID, current and proposed Maturity,
-  and evidence for each decision;
-- Revision Evidence: source, actor, exact `captured_at` field or apply-time
-  derivation, affected owner, revision identities, semantic change relations,
-  exact diff, and evidence destination;
-- Semantic Quality Gate: all required checks, status, checked scope, evidence,
-  whether a finding blocks the write, and the complete bundled-validator report
-  for each transition record;
-- skipped writes and no-ops: considered targets or conventions not selected;
-- read-back plan: exact properties, relations, content, deletion results, and
-  revision identity that will be compared after applying;
-- questions: only blockers that prevent a correct write.
+1. The **review layer** is the primary interface. It states what changes, where,
+   and with what semantic effect in ordinary language; renders changed fields as
+   provider-like tables; shows the complete final page or section; and makes every
+   deletion explicit. A reviewer can enumerate every mutation without reading
+   serialized provider state or decoding provider IDs.
+2. The **exact evidence layer** retains complete provider inputs, before/after
+   states, stable IDs, transition JSON, and validator reports in collapsed
+   technical-evidence toggles. It proves the review layer without becoming the
+   interface the human must diff.
 
-The before and after views are the approval boundary. Do not hide content behind
-summaries, ellipses, placeholders, or implementation notes. Render the exact
-provider representation that will exist after approval, including explicit Kind
-or registered mapping and Maturity representation.
+The review layer and exact evidence layer must describe the same complete change
+set. A mutation, property, relation, content change, or deletion that appears in
+only one layer invalidates the draft.
 
-Write the draft to the OS temp directory, open it for the user, and report the
-absolute path in chat. If any blocking risk remains, label the draft blocked and
-ask only the question needed to resolve it. Otherwise ask exactly: "Should I apply
+Before opening the draft, validate its review structure from the installed Capture
+skill directory:
+
+```sh
+python3 scripts/validate-approval-draft.py <draft.html>
+```
+
+Revise the HTML until the validator returns `Pass`. Treat a missing validator, exit
+status `2`, or `Block` disposition as a blocking deterministic failure. Then write
+the draft to the OS temp directory, open it for the user, and report the absolute
+path in chat.
+
+If any semantic or deterministic blocker remains, label the draft blocked and ask
+only the question needed to resolve it. Otherwise ask exactly: "Should I apply
 these exact KB writes now?"
 
-Completion criterion: the user can evaluate the semantic decisions and approve or
-reject the exact KB mutations from the HTML file without hidden conversation
-context.
+Completion criterion: the approval-draft validator passes, and the user can list
+every proposed mutation and evaluate its semantic effect from the visible review
+layer without opening technical evidence or relying on hidden conversation context.
 
 ### 6. Ask For Fresh Approval
 

--- a/cfg/home/agents/skills/capture/contracts/capture-transition-v1.json
+++ b/cfg/home/agents/skills/capture/contracts/capture-transition-v1.json
@@ -19,6 +19,7 @@
   "maturity": ["Raw", "Developing", "Stable"],
   "operations": ["create", "update", "replace-section", "delete"],
   "revision_relations": ["supersedes", "revises", "invalidates"],
+  "captured_at_derivations": ["provider-created-time"],
   "normative_forces": ["must", "should", "may"],
   "assertion_required_fields": {
     "state": ["observed_at"],

--- a/cfg/home/agents/skills/capture/scripts/validate-approval-draft.py
+++ b/cfg/home/agents/skills/capture/scripts/validate-approval-draft.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Validate that a Capture HTML draft is reviewable before it is opened."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+
+VOID_TAGS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+
+
+def classes(attributes: dict[str, str | None]) -> set[str]:
+    return set((attributes.get("class") or "").split())
+
+
+class DraftParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: list[dict[str, Any]] = []
+        self.mutations: list[dict[str, Any]] = []
+        self.current: dict[str, Any] | None = None
+        self.body_contract: str | None = None
+        self.draft_id: str | None = None
+        self.proposed_results = False
+        self.raw_outside_evidence = 0
+        self.outline_links: list[dict[str, str]] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        raw_attributes: list[tuple[str, str | None]],
+    ) -> None:
+        attributes = dict(raw_attributes)
+        tag_classes = classes(attributes)
+        frame: dict[str, Any] = {
+            "tag": tag,
+            "classes": tag_classes,
+            "region": None,
+            "technical": False,
+            "change_table": False,
+            "thead": False,
+            "outside_pre": False,
+            "text": [],
+        }
+
+        if tag == "a" and "data-mutation-link" in attributes:
+            frame["outline_link"] = {
+                "href": attributes.get("href") or "",
+                "text": [],
+            }
+
+        if tag == "body":
+            self.body_contract = attributes.get("data-capture-draft-version")
+            self.draft_id = attributes.get("data-draft-id")
+        if tag == "section" and attributes.get("id") == "proposed-results":
+            self.proposed_results = True
+        raw_provider_state = "data-raw-provider-state" in attributes
+        if raw_provider_state and not self._inside("technical"):
+            self.raw_outside_evidence += 1
+        if tag == "pre" and not self._inside("technical"):
+            frame["outside_pre"] = True
+        if tag == "details" and "technical-evidence" in tag_classes:
+            frame["technical"] = True
+
+        if tag == "article" and "mutation" in tag_classes:
+            if self.current is not None:
+                raise ValueError("nested mutation articles are unsupported")
+            self.current = {
+                "id": attributes.get("data-mutation-id") or "",
+                "summary": [],
+                "provider_preview": [],
+                "unchanged_scope": [],
+                "visible_text": [],
+                "exact_before_text": [],
+                "exact_after_text": [],
+                "change_rows": 0,
+                "technical_evidence": 0,
+                "technical_open": False,
+                "exact_before": 0,
+                "exact_after": 0,
+                "raw_provider_state": 0,
+            }
+            frame["mutation_root"] = True
+
+        if self.current is not None:
+            if "change-summary" in tag_classes:
+                frame["region"] = "summary"
+            elif "provider-preview" in tag_classes:
+                frame["region"] = "provider_preview"
+            elif "unchanged-scope" in tag_classes:
+                frame["region"] = "unchanged_scope"
+
+            if tag == "table" and "change-table" in tag_classes:
+                frame["change_table"] = True
+            if tag == "thead":
+                frame["thead"] = True
+            if tag == "tr" and self._inside("change_table") and not self._inside("thead"):
+                self.current["change_rows"] += 1
+
+            if tag == "details" and "technical-evidence" in tag_classes:
+                self.current["technical_evidence"] += 1
+                if "open" in attributes:
+                    self.current["technical_open"] = True
+
+            if "data-exact-before" in attributes and self._inside("technical"):
+                self.current["exact_before"] += 1
+                frame["region"] = "exact_before_text"
+            if "data-exact-after" in attributes and self._inside("technical"):
+                self.current["exact_after"] += 1
+                frame["region"] = "exact_after_text"
+            if raw_provider_state:
+                self.current["raw_provider_state"] += 1
+
+        if tag not in VOID_TAGS:
+            self.stack.append(frame)
+
+    def handle_endtag(self, tag: str) -> None:
+        match = next(
+            (index for index in range(len(self.stack) - 1, -1, -1) if self.stack[index]["tag"] == tag),
+            None,
+        )
+        if match is None:
+            return
+        frame = self.stack[match]
+        if frame.get("outline_link"):
+            link = frame["outline_link"]
+            self.outline_links.append(
+                {
+                    "href": link["href"],
+                    "text": " ".join(link["text"]).strip(),
+                }
+            )
+        del self.stack[match:]
+        if frame.get("outside_pre"):
+            serialized = " ".join(frame["text"]).strip()
+            if serialized.startswith(("{", "[")):
+                try:
+                    json.loads(serialized)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    self.raw_outside_evidence += 1
+        if frame.get("mutation_root"):
+            assert self.current is not None
+            self.mutations.append(self.current)
+            self.current = None
+
+    def handle_startendtag(
+        self,
+        tag: str,
+        attributes: list[tuple[str, str | None]],
+    ) -> None:
+        self.handle_starttag(tag, attributes)
+        if tag not in VOID_TAGS:
+            self.handle_endtag(tag)
+
+    def handle_data(self, data: str) -> None:
+        for frame in self.stack:
+            if frame.get("outside_pre"):
+                frame["text"].append(data)
+            if frame.get("outline_link") and data.strip():
+                frame["outline_link"]["text"].append(data.strip())
+        if self.current is None or not data.strip():
+            return
+        if not self._inside("technical"):
+            self.current["visible_text"].append(data.strip())
+        for region in (
+            "summary",
+            "provider_preview",
+            "unchanged_scope",
+            "exact_before_text",
+            "exact_after_text",
+        ):
+            if self._inside_region(region):
+                self.current[region].append(data.strip())
+
+    def _inside(self, key: str) -> bool:
+        return any(frame.get(key) for frame in self.stack)
+
+    def _inside_region(self, region: str) -> bool:
+        return any(frame.get("region") == region for frame in self.stack)
+
+
+def result(check: str, passed: bool, evidence: str) -> dict[str, Any]:
+    return {
+        "check": check,
+        "status": "Pass" if passed else "Flag",
+        "evidence": evidence,
+        "blocking": not passed,
+    }
+
+
+def complete_human_text(parts: list[str]) -> bool:
+    text = " ".join(parts).strip()
+    placeholders = ("{{", "}}", "...", "[placeholder]", "todo", "tbd")
+    return bool(text) and not any(token in text.lower() for token in placeholders)
+
+
+def validate(path: Path) -> tuple[int, dict[str, Any]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        report = {
+            "disposition": "Block",
+            "path": str(path),
+            "mutation_count": 0,
+            "results": [result("artifact-read", False, str(error))],
+            "write_allowed": False,
+        }
+        return 2, report
+
+    parser = DraftParser()
+    try:
+        parser.feed(text)
+        parser.close()
+    except (ValueError, AssertionError) as error:
+        report = {
+            "disposition": "Block",
+            "path": str(path),
+            "mutation_count": len(parser.mutations),
+            "results": [result("html-structure", False, str(error))],
+            "write_allowed": False,
+        }
+        return 2, report
+
+    checks = [
+        result(
+            "draft-contract",
+            parser.body_contract == "1" and bool(parser.draft_id),
+            f"body version={parser.body_contract!r}; draft_id={parser.draft_id!r}",
+        ),
+        result(
+            "proposed-results",
+            parser.proposed_results and bool(parser.mutations),
+            f"proposed-results={parser.proposed_results}; mutations={len(parser.mutations)}",
+        ),
+        result(
+            "raw-evidence-placement",
+            parser.raw_outside_evidence == 0,
+            f"raw provider-state blocks outside closed technical evidence={parser.raw_outside_evidence}",
+        ),
+    ]
+
+    ids = [mutation["id"] for mutation in parser.mutations]
+    checks.append(
+        result(
+            "mutation-identities",
+            bool(ids) and all(ids) and len(ids) == len(set(ids)),
+            f"mutation ids={ids}",
+        )
+    )
+    outline_targets = [
+        link["href"][1:] if link["href"].startswith("#") else ""
+        for link in parser.outline_links
+    ]
+    checks.append(
+        result(
+            "mutation-outline",
+            outline_targets == ids
+            and all(link["text"] for link in parser.outline_links),
+            f"outline targets={outline_targets}; mutation ids={ids}; "
+            f"labels={[link['text'] for link in parser.outline_links]}",
+        )
+    )
+
+    for mutation in parser.mutations:
+        mutation_id = mutation["id"] or "<missing>"
+        reviewable = (
+            complete_human_text(mutation["summary"])
+            and mutation["change_rows"] > 0
+            and complete_human_text(mutation["provider_preview"])
+            and complete_human_text(mutation["unchanged_scope"])
+            and complete_human_text(mutation["visible_text"])
+        )
+        checks.append(
+            result(
+                f"review-layer:{mutation_id}",
+                reviewable,
+                "summary={} change_rows={} provider_preview={} unchanged_scope={}".format(
+                    bool(mutation["summary"]),
+                    mutation["change_rows"],
+                    bool(mutation["provider_preview"]),
+                    bool(mutation["unchanged_scope"]),
+                ),
+            )
+        )
+        exact = (
+            mutation["technical_evidence"] == 1
+            and not mutation["technical_open"]
+            and mutation["exact_before"] == 1
+            and mutation["exact_after"] == 1
+            and bool(" ".join(mutation["exact_before_text"]).strip())
+            and bool(" ".join(mutation["exact_after_text"]).strip())
+            and mutation["raw_provider_state"] > 0
+        )
+        checks.append(
+            result(
+                f"exact-evidence:{mutation_id}",
+                exact,
+                "technical_evidence={} open={} exact_before={} exact_after={} raw_blocks={}".format(
+                    mutation["technical_evidence"],
+                    mutation["technical_open"],
+                    mutation["exact_before"],
+                    mutation["exact_after"],
+                    mutation["raw_provider_state"],
+                ),
+            )
+        )
+
+    blocked = any(check["blocking"] for check in checks)
+    report = {
+        "disposition": "Block" if blocked else "Pass",
+        "path": str(path),
+        "draft_id": parser.draft_id,
+        "mutation_count": len(parser.mutations),
+        "results": checks,
+        "write_allowed": False,
+        "note": "Reviewability validation does not grant human approval or write authority.",
+    }
+    return (2 if blocked else 0), report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("draft", type=Path)
+    arguments = parser.parse_args()
+    code, report = validate(arguments.draft)
+    json.dump(report, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cfg/home/agents/skills/capture/scripts/validate-capture-transition.py
+++ b/cfg/home/agents/skills/capture/scripts/validate-capture-transition.py
@@ -56,6 +56,17 @@ def is_datetime(value: Any) -> bool:
     return "T" in value and parsed.tzinfo is not None
 
 
+def is_captured_at(value: Any, contract: dict[str, Any]) -> bool:
+    if is_datetime(value):
+        return True
+    return (
+        isinstance(value, dict)
+        and value.get("derivation") in contract.get("captured_at_derivations", [])
+        and isinstance(value.get("field"), str)
+        and bool(value["field"].strip())
+    )
+
+
 def stable_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
@@ -309,8 +320,13 @@ def validate(
 
     revision = record.get("revision", {})
     bad_time: list[str] = []
-    if not isinstance(revision, dict) or not is_datetime(revision.get("captured_at")):
-        bad_time.append("revision.captured_at must be an absolute ISO date-time")
+    if not isinstance(revision, dict) or not is_captured_at(
+        revision.get("captured_at"), contract
+    ):
+        bad_time.append(
+            "revision.captured_at must be an absolute ISO date-time or a registered "
+            "provider apply-time derivation with a field"
+        )
     if kind == "state":
         for index, assertion in enumerate(assertions if isinstance(assertions, list) else []):
             if not isinstance(assertion, dict) or not is_date(assertion.get("observed_at")):


### PR DESCRIPTION
## What changed

- Materialize the updated Capture review interface into the workspace skill source.
- Include the ordered mutation-card sidebar contract and approval-draft validator.
- Keep the materialized transition contract aligned with the kb-infra source.

## Why

Installed skill copies are materialized rather than symlinked, so the workspace source must remain byte-for-byte aligned with kb-infra.

## Impact

Agents using the workspace-installed Capture skill receive the same human-readable, validator-enforced approval interface. No live KB writes or KB page-content changes are included.

## Root cause

The installed copy previously inherited the same raw-state-first approval interface as the source skill.

## Validation

- The materialized Capture skill passes the bundled skill validator.
- The source and materialized Capture directories compare identically.
- The 16-operation dry-run passes the materialized approval-draft validator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer approval drafts with separate review and exact-evidence sections.
  - Added richer previews showing complete change summaries, before/after details, provider evidence, and revision history.
  - Added improved navigation, mutation highlighting, property differences, and technical-evidence panels.

- **Bug Fixes**
  - Draft validation now detects incomplete, inconsistent, or incorrectly ordered changes before approval.
  - Capture records can now accept provider-derived capture timestamps when valid.

- **Documentation**
  - Updated capture guidance with stricter reviewability and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->